### PR TITLE
Concept: After ability roll special messages

### DIFF
--- a/Objects/AutoFillMultiRoller.ttslua
+++ b/Objects/AutoFillMultiRoller.ttslua
@@ -989,6 +989,7 @@ function autoFillCoroutine()
         rollType = doClick and autofillTypeAttributes.rollType or false,
         extraModifiers = extraUnitModifiers or false,
         rollObjectGuid = _rollOnSelf and self.getGUID(),
+        opponentUnitTypeToCount = enemyUnitTypeToCount
     })
     if not doClick then
         printToAll('AutoFill: left click to fill and roll.', params.clickerColor)

--- a/Objects/AutoFillMultiRoller.ttslua
+++ b/Objects/AutoFillMultiRoller.ttslua
@@ -989,7 +989,6 @@ function autoFillCoroutine()
         rollType = doClick and autofillTypeAttributes.rollType or false,
         extraModifiers = extraUnitModifiers or false,
         rollObjectGuid = _rollOnSelf and self.getGUID(),
-        opponentUnitTypeToCount = enemyUnitTypeToCount
     })
     if not doClick then
         printToAll('AutoFill: left click to fill and roll.', params.clickerColor)

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -1053,34 +1053,36 @@ local _unitModifiers = {
         type = TYPE.CHOOSE,
         toggleActive = true,
         apply = function(unitAttrs, params)
+            local afbBest = false
+            local bombardentBest = false
+            local spaceCannonBest = false
             for unitType, attr in pairs(unitAttrs) do
-                local best = false
-                if attr.antiFighterBarrage and (params.myUnitTypeToCount[unitType] or 0) > 0 then
-                    if (not best) or (attr.antiFighterBarrage.hit < best.antiFighterBarrage.hit) then
-                        best = attr
+                local unitTypeCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.antiFighterBarrage and unitTypeCount > 0 then
+                    if (not afbBest) or (attr.antiFighterBarrage.hit < afbBest.antiFighterBarrage.hit) then
+                        afbBest = attr
                     end
                 end
-                if best then
-                    best.antiFighterBarrage.extraDice = (best.antiFighterBarrage.extraDice or 0) + 1
-                end
-                local best = false
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
-                    if (not best) or (attr.bombardment.hit < best.bombardment.hit) then
-                        best = attr
+                if attr.bombardment and unitTypeCount > 0 then
+                    if (not bombardentBest) or (attr.bombardment.hit < bombardentBest.bombardment.hit) then
+                        bombardentBest = attr
                     end
                 end
-                if best then
-                    best.bombardment.extraDice = (best.bombardment.extraDice or 0) + 1
-                end
-                local best = false
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
-                    if (not best) or (attr.spaceCannon.hit < best.spaceCannon.hit) then
-                        best = attr
+                if attr.spaceCannon and unitTypeCount > 0 then
+                    if (not spaceCannonBest) or (attr.spaceCannon.hit < spaceCannonBest.spaceCannon.hit) then
+                        spaceCannonBest = attr
                     end
                 end
-                if best then
-                    best.spaceCannon.extraDice = (best.spaceCannon.extraDice or 0) + 1
-                end
+            end
+
+            if bombardentBest then
+                bombardentBest.bombardment.extraDice = (bombardentBest.bombardment.extraDice or 0) + 1
+            end
+            if spaceCannonBest then
+                spaceCannonBest.spaceCannon.extraDice = (spaceCannonBest.spaceCannon.extraDice or 0) + 1
+            end
+            if afbBest then
+                afbBest.antiFighterBarrage.extraDice = (afbBest.antiFighterBarrage.extraDice or 0) + 1
             end
         end
     },

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -1029,36 +1029,38 @@ local _unitModifiers = {
         type = TYPE.CHOOSE,
         toggleActive = true,
         apply = function(unitAttrs, params)
-            local afbBest = false
-            local bombardentBest = false
-            local spaceCannonBest = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                local unitTypeCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
-                if attr.antiFighterBarrage and unitTypeCount > 0 then
-                    if (not afbBest) or (attr.antiFighterBarrage.hit < afbBest.antiFighterBarrage.hit) then
-                        afbBest = attr
-                    end
-                end
-                if attr.bombardment and unitTypeCount > 0 then
-                    if (not bombardentBest) or (attr.bombardment.hit < bombardentBest.bombardment.hit) then
-                        bombardentBest = attr
-                    end
-                end
-                if attr.spaceCannon and unitTypeCount > 0 then
-                    if (not spaceCannonBest) or (attr.spaceCannon.hit < spaceCannonBest.spaceCannon.hit) then
-                        spaceCannonBest = attr
+                if attr.antiFighterBarrage and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                    if (not best) or (attr.antiFighterBarrage.hit < best.antiFighterBarrage.hit) then
+                        best = attr
                     end
                 end
             end
-
-            if bombardentBest then
-                bombardentBest.bombardment.extraDice = (bombardentBest.bombardment.extraDice or 0) + 1
+            if best then
+                best.antiFighterBarrage.extraDice = (best.antiFighterBarrage.extraDice or 0) + 1
             end
-            if spaceCannonBest then
-                spaceCannonBest.spaceCannon.extraDice = (spaceCannonBest.spaceCannon.extraDice or 0) + 1
+            local best = false
+            for unitType, attr in pairs(unitAttrs) do
+                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                    if (not best) or (attr.bombardment.hit < best.bombardment.hit) then
+                        best = attr
+                    end
+                end
             end
-            if afbBest then
-                afbBest.antiFighterBarrage.extraDice = (afbBest.antiFighterBarrage.extraDice or 0) + 1
+            if best then
+                best.bombardment.extraDice = (best.bombardment.extraDice or 0) + 1
+            end
+            local best = false
+            for unitType, attr in pairs(unitAttrs) do
+                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                    if (not best) or (attr.spaceCannon.hit < best.spaceCannon.hit) then
+                        best = attr
+                    end
+                end
+            end
+            if best then
+                best.spaceCannon.extraDice = (best.spaceCannon.extraDice or 0) + 1
             end
         end
     },

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -804,30 +804,6 @@ local _unitModifiers = {
         end
     },
 
-    ['Raid Formation'] = {
-        description = 'ANTI-FIGHTER BARRAGE hits in excess of fighter targets cause SUSTAIN DAMAGE units to become damaged.',
-        owner = OWNER.SELF,
-        type = TYPE.MUTATE,
-        apply = function(unitAttrs, params)
-            -- This is called by automatic-fill-multiroller tool (with opponent ship context),
-            -- then later it is called again by multiroller without opponent context. To fix
-            -- this, explore injecting opponent-unitType-to-Count and using that in multiroller.
-
-            -- Ensure we have some opponent data, this 'apply' requires that minimum context.
-            if not params.opponentUnitTypeToCount then
-                return
-            end
-
-            local opponentFighterCount = params.opponentUnitTypeToCount['Fighter'] or 0
-            for unitType, attr in pairs(unitAttrs) do
-                -- This needs to be shared across all unit types...somehow.
-                if attr.antiFighterBarrage then
-                    attr.antiFighterBarrage.availableTargets = opponentFighterCount
-                end
-            end
-        end
-    },
-
     ['Regulated Conscription'] = {
         description = 'Fighters and infantry cost 1 each',
         owner = OWNER.ANY,

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -172,7 +172,7 @@ local _unitOverrides = {
     ['Super-Dreadnought II'] = { upgrade = 'Dreadnought', bombardment = { dice = 1, hit = 4 }, spaceCombat = { hit = 4 }, move = 2, capacity = 2 },
     -- PoK faction unit overrides and upgrades
     ['Strike Wing Alpha I'] = { override = 'Destroyer', spaceCombat = { hit = 8 }, capacity = 1 },
-    ['Strike Wing Alpha II'] = { upgrade = 'Destroyer', antiFighterBarrage = { dice = 3, hit = 6, extraHitsOn = { value = 9, messagePrefix = 'Rolls which destroy 1 infantry in the Active System\'s space area: ' } }, spaceCombat = { hit = 7 }, capacity = 1 },
+    ['Strike Wing Alpha II'] = { upgrade = 'Destroyer', antiFighterBarrage = { dice = 3, hit = 6, extraHitsOn = { value = 9, message = '${PlayerName} destroys ${ExtraHits} of the opponent\'s Infantry in the space area.' } }, spaceCombat = { hit = 7 }, capacity = 1 },
     ['Crimson Legionnaire I'] = { override = 'Infantry', groundCombat = { hit = 8 } },
     ['Crimson Legionnaire II'] = { upgrade = 'Infantry', groundCombat = { hit = 7 } },
     ['Saturn Engine I'] = { override = 'Cruiser', spaceCombat = { hit = 7 }, capacity = 1 },
@@ -945,7 +945,7 @@ local _unitModifiers = {
     },
 
     ['Ta Zern'] = {
-        description = 'You may reroll any dice. (Automatic tool: Reroll all misses)',
+        description = 'You may reroll any dice. (When active will reroll all misses)',
         leader = LEADER.COMMANDER,
         owner = OWNER.SELF,
         type = TYPE.ADJUST,

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -172,7 +172,7 @@ local _unitOverrides = {
     ['Super-Dreadnought II'] = { upgrade = 'Dreadnought', bombardment = { dice = 1, hit = 4 }, spaceCombat = { hit = 4 }, move = 2, capacity = 2 },
     -- PoK faction unit overrides and upgrades
     ['Strike Wing Alpha I'] = { override = 'Destroyer', spaceCombat = { hit = 8 }, capacity = 1 },
-    ['Strike Wing Alpha II'] = { upgrade = 'Destroyer', antiFighterBarrage = { dice = 3, hit = 6 }, spaceCombat = { hit = 7 }, capacity = 1 },
+    ['Strike Wing Alpha II'] = { upgrade = 'Destroyer', antiFighterBarrage = { dice = 3, hit = 6, extraHitsOn = { value = 9, messagePrefix = 'Rolls which destroy 1 infantry in the Active System\'s space area: ' } }, spaceCombat = { hit = 7 }, capacity = 1 },
     ['Crimson Legionnaire I'] = { override = 'Infantry', groundCombat = { hit = 8 } },
     ['Crimson Legionnaire II'] = { upgrade = 'Infantry', groundCombat = { hit = 7 } },
     ['Saturn Engine I'] = { override = 'Cruiser', spaceCombat = { hit = 7 }, capacity = 1 },
@@ -804,6 +804,30 @@ local _unitModifiers = {
         end
     },
 
+    ['Raid Formation'] = {
+        description = 'ANTI-FIGHTER BARRAGE hits in excess of fighter targets cause SUSTAIN DAMAGE units to become damaged.',
+        owner = OWNER.SELF,
+        type = TYPE.MUTATE,
+        apply = function(unitAttrs, params)
+            -- This is called by automatic-fill-multiroller tool (with opponent ship context),
+            -- then later it is called again by multiroller without opponent context. To fix
+            -- this, explore injecting opponent-unitType-to-Count and using that in multiroller.
+
+            -- Ensure we have some opponent data, this 'apply' requires that minimum context.
+            if not params.opponentUnitTypeToCount then
+                return
+            end
+
+            local opponentFighterCount = params.opponentUnitTypeToCount['Fighter'] or 0
+            for unitType, attr in pairs(unitAttrs) do
+                -- This needs to be shared across all unit types...somehow.
+                if attr.antiFighterBarrage then
+                    attr.antiFighterBarrage.availableTargets = opponentFighterCount
+                end
+            end
+        end
+    },
+
     ['Regulated Conscription'] = {
         description = 'Fighters and infantry cost 1 each',
         owner = OWNER.ANY,
@@ -915,6 +939,27 @@ local _unitModifiers = {
                 end
                 if attr.groundCombat then
                     attr.groundCombat.hit = attr.groundCombat.hit - 1
+                end
+            end
+        end
+    },
+
+    ['Ta Zern'] = {
+        description = 'You may reroll any dice. (Automatic tool: Reroll all misses)',
+        leader = LEADER.COMMANDER,
+        owner = OWNER.SELF,
+        type = TYPE.ADJUST,
+        toggleActive = true,
+        apply = function(unitAttrs)
+            for unitType, attr in pairs(unitAttrs) do
+                if attr.spaceCannon then
+                    attr.spaceCannon.rerollMisses = 999 -- Reroll ALL misses
+                end
+                if attr.bombardment then
+                    attr.bombardment.rerollMisses = 999 -- Reroll ALL misses
+                end
+                if attr.antiFighterBarrage then
+                    attr.antiFighterBarrage.rerollMisses = 999 -- Reroll ALL misses
                 end
             end
         end

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -1421,9 +1421,17 @@ function getColorToUnitModifiers()
 
     -- Add commanders (including Alliance and Imperia sharing).
     local colorToCommanders = _factionHelper.getColorToCommanders()
+    local toggleActiveCommanderToColor = {}
     for color, commanders in pairs(colorToCommanders) do
         for _, commander in ipairs(commanders) do
-            addModifier(color, commander)
+            local unitModifier = _unitModifiers[commander]
+            if not unitModifier or not unitModifier.toggleActive then
+                addModifier(color, commander)
+            else
+                -- Toggle Active commanders require additional checks
+                toggleActiveCommanderToColor[commander] = toggleActiveCommanderToColor[commander] or {}
+                table.insert(toggleActiveCommanderToColor[commander], color)
+            end
         end
     end
 
@@ -1499,6 +1507,15 @@ function getColorToUnitModifiers()
                 local color = _zoneHelper.zoneFromPosition(object.getPosition())
                 if sardakk and sardakk.color and sardakk.color ~= color then
                     addModifier(sardakk.color, name)
+                end
+            end
+
+            local commanderColors = toggleActiveCommanderToColor[name]
+            if commanderColors then
+                -- This object has passed any 'toggle active' checks. Add commander to specified colors.
+                -- These come from faction.commander, Alliance promissory notes, and Imperia
+                for _, color in ipairs(commanderColors) do
+                    addModifier(color, name)
                 end
             end
 

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -929,13 +929,13 @@ local _unitModifiers = {
         apply = function(unitAttrs)
             for unitType, attr in pairs(unitAttrs) do
                 if attr.spaceCannon then
-                    attr.spaceCannon.rerollMisses = 999 -- Reroll ALL misses
+                    attr.spaceCannon.rerollMisses = true
                 end
                 if attr.bombardment then
-                    attr.bombardment.rerollMisses = 999 -- Reroll ALL misses
+                    attr.bombardment.rerollMisses = true
                 end
                 if attr.antiFighterBarrage then
-                    attr.antiFighterBarrage.rerollMisses = 999 -- Reroll ALL misses
+                    attr.antiFighterBarrage.rerollMisses = true
                 end
             end
         end

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -569,7 +569,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.groundCombat and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.groundCombat and unitCount > 0 then
                     if (not best) or attr.groundCombat.hit < best.groundCombat.hit then
                         best = attr
                     end
@@ -763,7 +765,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCannon and unitCount > 0 then
                     if (not best) or attr.spaceCannon.hit < best.spaceCannon.hit then
                         best = attr
                     end
@@ -774,7 +778,9 @@ local _unitModifiers = {
             end
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.bombardment and unitCount > 0 then
                     if (not best) or attr.bombardment.hit < best.bombardment.hit then
                         best = attr
                     end
@@ -867,9 +873,11 @@ local _unitModifiers = {
         type = TYPE.CHOOSE,
         excludeFaction = 'The Argent Flight',
         apply = function(unitAttrs, params)
-            best = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.antiFighterBarrage and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.antiFighterBarrage and unitCount > 0 then
                     if (not best) or (attr.antiFighterBarrage.hit < best.antiFighterBarrage.hit) then
                         best = attr
                     end
@@ -878,9 +886,11 @@ local _unitModifiers = {
             if best then
                 best.antiFighterBarrage.extraDice = (best.antiFighterBarrage.extraDice or 0) + 1
             end
-            best = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.bombardment and unitCount > 0 then
                     if (not best) or (attr.bombardment.hit < best.bombardment.hit) then
                         best = attr
                     end
@@ -889,9 +899,11 @@ local _unitModifiers = {
             if best then
                 best.bombardment.extraDice = (best.bombardment.extraDice or 0) + 1
             end
-            best = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCannon and unitCount > 0 then
                     if (not best) or (attr.spaceCannon.hit < best.spaceCannon.hit) then
                         best = attr
                     end
@@ -1031,7 +1043,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.antiFighterBarrage and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.antiFighterBarrage and unitCount > 0 then
                     if (not best) or (attr.antiFighterBarrage.hit < best.antiFighterBarrage.hit) then
                         best = attr
                     end
@@ -1042,7 +1056,9 @@ local _unitModifiers = {
             end
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.bombardment and unitCount > 0 then
                     if (not best) or (attr.bombardment.hit < best.bombardment.hit) then
                         best = attr
                     end
@@ -1053,7 +1069,9 @@ local _unitModifiers = {
             end
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCannon and unitCount > 0 then
                     if (not best) or (attr.spaceCannon.hit < best.spaceCannon.hit) then
                         best = attr
                     end
@@ -1090,7 +1108,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCombat and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCombat and unitCount > 0 then
                     if (not best) or (attr.spaceCombat.hit < best.spaceCombat.hit) then
                         best = attr
                     end

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -1061,7 +1061,7 @@ function Roller_RollDiceCoroutine()
     -- Wait for dice, extract roll values.
     local timeout = Time.time + 3
     for _, dice in ipairs(Roller._dice) do
-        dice._rollValues = {}
+        dice._rollData = {}
         for _, guid in ipairs(dice._guids) do
             local die = false
             while true do
@@ -1073,43 +1073,39 @@ function Roller_RollDiceCoroutine()
                 end
             end
             if die then
-                table.insert(dice._rollValues, die.getValue() or 0)
+                local rollData = { guid = guid, finalValue = die.getValue() or 0 }
+                table.insert(dice._rollData, rollData)
                 die.interactable = true
             end
         end
     end
     coroutine.yield(0)
 
-    -- Reroll misses for any dice that have available rerolls
+    -- Find dice that reroll-on-miss, and prep them for reroll.
     local conductRerolls = false
-    local rerollingDiceByType = {}
     for _, dice in ipairs(Roller._dice) do
-        local availableRerolls = dice.rerollMisses or 0
-        if availableRerolls > 0 then
+        local rerollMisses = dice.rerollMisses or false
+        if rerollMisses then
             dice._rerollGuids = {}
-            for i, guid in ipairs(dice._guids) do
-                -- These prooooobably sync up by index. Ensure they do before any merges.
-                local rollValue = dice._rollValues[i]
+            for _, rollData in ipairs(dice._rollData) do
+                local guid = rollData.guid
+                local origValue = rollData.finalValue
 
-                if rollValue < dice.hitValue then
+                -- Track dice GUID for reroll
+                -- Set the die's "initial roll" value, unset it's "final roll" value
+                if origValue < dice.hitValue then
                     table.insert(dice._rerollGuids, guid)
+                    rollData.origValue = origValue
+                    rollData.finalValue = false
                     conductRerolls = true
-                    availableRerolls = availableRerolls - 1
-                    if availableRerolls == 0 then
-                        break
-                    end
                 end
-            end
-
-            if #dice._rerollGuids > 0 then
-                dice._originalRollValues = dice._rollValues
-                dice._rollValues = {}
             end
         end
     end
 
     -- For any rerolls found, roll the dice! And watch for results.
     if conductRerolls then
+        -- Roll dice in _rerollGuids
         for _, dice in ipairs(Roller._dice) do
             for _, guid in ipairs(dice._rerollGuids or {}) do
                 local die = getObjectFromGUID(guid)
@@ -1119,21 +1115,22 @@ function Roller_RollDiceCoroutine()
         end
         coroutine.yield(0)
 
+        -- Watch ALL dice, and update the 'final value' 
         local timeout = Time.time + 3
         for _, dice in ipairs(Roller._dice) do
-            dice._rollValues = {}
-            for _, guid in ipairs(dice._guids) do
+            for _, rollData in ipairs(dice._rollData) do
                 local die = false
                 while true do
-                    die = getObjectFromGUID(guid)  -- re-get every time, can be deleted
+                    die = getObjectFromGUID(rollData.guid)  -- re-get every time, can be deleted
                     if die and (not die.resting) and Time.time < timeout then
                         coroutine.yield(0)
                     else
                         break
                     end
                 end
-                if die then
-                    table.insert(dice._rollValues, die.getValue() or 0)
+                -- If we have a die, but not a final result, set the final result
+                if die and not rollData.finalValue then
+                    rollData.finalValue = die.getValue() or 0
                     die.interactable = true
                 end
             end
@@ -1155,7 +1152,8 @@ function Roller_RollDiceCoroutine()
         local rollValues = {}
         local critCount = 0
         local unitHitCount = 0
-        for i, rollValue in ipairs(dice._rollValues) do
+        for i, rollData in ipairs(dice._rollData) do
+            local rollValue = rollData.finalValue
             local prefix = ''
             local suffix = ''
             if rollValue >= dice.hitValue then
@@ -1175,11 +1173,9 @@ function Roller_RollDiceCoroutine()
                     critCount = critCount + 1
                 end
             end
-            if dice._originalRollValues and dice.rerollMisses then
-                local originalRollValue = dice._originalRollValues[i]
-                if originalRollValue ~= rollValue then
-                    prefix = dice._originalRollValues[i] .. '->'
-                end
+            if dice.rerollMisses and rollData.origValue then
+                local originalRollValue = rollData.origValue
+                prefix = originalRollValue .. '->'
             end
             table.insert(rollValues, prefix .. rollValue .. suffix)
             setHitCount(dice.unitId, unitHitCount)
@@ -1236,7 +1232,7 @@ function rollDiceForAbility(player, ability)
                 critCount = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.count,
                 critValue = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.value,
                 critMessage = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.message,
-                rerollMisses = abilityAttrs.rerollMisses or 0,
+                rerollMisses = abilityAttrs.rerollMisses,
                 unitName = unit_stats.name,
                 unitId = unit_id
             })

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -762,8 +762,15 @@ end
 
 function setUnitCount(unit, count)
     assert(type(unit) == 'string' and type(count) == 'number')
-    self.UI.setValue(unit .. ".unitCount", count)
-    _unitTypeToCount[unit] = count
+
+    -- Restrict to allowable unit types
+    for _, unitType in ipairs(UNIT_TYPES) do
+        if unitType == unit then
+            self.UI.setValue(unit .. ".unitCount", count)
+            _unitTypeToCount[unit] = count
+            return
+        end
+    end
 end
 
 function getUnitCount(unit)

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -1098,11 +1098,7 @@ function Roller_RollDiceCoroutine()
             end
 
             if #dice._rerollGuids > 0 then
-                dice._originalRollValues = {}
-                -- Copy
-                for _, origRollValue in ipairs(dice._rollValues) do
-                    table.insert(dice._originalRollValues, origRollValue)
-                end
+                dice._originalRollValues = dice._rollValues
                 dice._rollValues = {}
             end
         end
@@ -1155,14 +1151,15 @@ function Roller_RollDiceCoroutine()
         local rollValues = {}
         local critCount = 0
         local unitHitCount = 0
-        for _, rollValue in ipairs(dice._rollValues) do
+        for i, rollValue in ipairs(dice._rollValues) do
+            local prefix = ''
             local suffix = ''
             if rollValue >= dice.hitValue then
                 hits = hits + 1
                 unitHitCount = unitHitCount + 1
                 suffix = '#'
             end
-            if (dice.critCount or dice.critMessagePrefix) and dice.critValue and (rollValue >= dice.critValue) then
+            if (dice.critCount or dice.critMessage) and dice.critValue and (rollValue >= dice.critValue) then
                 if dice.critCount then
                     hits = hits + dice.critCount
                     unitHitCount = unitHitCount + dice.critCount
@@ -1170,23 +1167,30 @@ function Roller_RollDiceCoroutine()
                         suffix = suffix .. '#'
                     end
                 end
-                if dice.critMessagePrefix then
+                if dice.critMessage then
                     critCount = critCount + 1
                 end
             end
-            table.insert(rollValues, rollValue .. suffix)
+            if dice._originalRollValues and dice.rerollMisses then
+                local originalRollValue = dice._originalRollValues[i]
+                if originalRollValue ~= rollValue then
+                    prefix = dice._originalRollValues[i] .. '->'
+                end
+            end
+            table.insert(rollValues, prefix .. rollValue .. suffix)
             setHitCount(dice.unitId, unitHitCount)
         end
 
         if dice._originalRollValues and dice.rerollMisses then
             local availableRerolls = dice.rerollMisses == 999 and 'all' or dice.rerollMisses
-            table.insert(specialMessages, dice.unitName .. ' rolled values before automatic reroll of ' .. availableRerolls .. ' misses: ' .. table.concat(dice._originalRollValues, ', '))
+            --table.insert(specialMessages, dice.unitName .. ' rolled values before automatic reroll of ' .. availableRerolls .. ' misses: ' .. table.concat(dice._originalRollValues, ', '))
         end
 
         table.insert(message, dice.unitName .. ' ' .. item .. table.concat(rollValues, ', '))
 
-        if critCount > 0 and dice.critMessagePrefix then
-            table.insert(specialMessages, dice.critMessagePrefix .. critCount)
+        if critCount > 0 and dice.critMessage then
+            local critMessage = dice.critMessage:gsub('%${PlayerName}', playerName):gsub('%${ExtraHits}', critCount)
+            table.insert(specialMessages, critMessage)
         end
 
         if dice.availableTargets and dice.availableTargets >= 0 then
@@ -1196,7 +1200,7 @@ function Roller_RollDiceCoroutine()
     broadcastToAll(playerName .. ' rolled: [ffffff]' .. table.concat(message, ', '), playerColor)
     broadcastToAll(playerName .. ' landed ' .. hits .. ' hit' .. (hits == 1 and '' or 's') .. '.', playerColor)
     for _, message in ipairs(specialMessages) do
-        broadcastToAll(playerName .. ': ' .. message)
+        broadcastToAll(message, playerColor)
     end
 
     Roller._setRollInProgress(false)
@@ -1236,7 +1240,7 @@ function rollDiceForAbility(player, ability)
                 hitValue = abilityAttrs.hit,
                 critCount = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.count,
                 critValue = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.value,
-                critMessagePrefix = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.messagePrefix,
+                critMessage = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.message,
                 availableTargets = abilityAttrs.availableTargets,
                 rerollMisses = abilityAttrs.rerollMisses or 0,
                 unitName = unit_stats.name,

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -763,6 +763,11 @@ function setUnitCount(unit, count)
     assert(type(unit) == 'string' and type(count) == 'number')
 
     -- Restrict to allowable unit types
+    -- Non-basic unit types may be dynamically injected;
+    -- we don't want to keep (and subsequently override)
+    -- any dynamic state. So when setting up a roll from
+    -- the "inject" method, ensure we are only tracking
+    -- the known unit types.
     for _, unitType in ipairs(UNIT_TYPES) do
         if unitType == unit then
             self.UI.setValue(unit .. ".unitCount", count)

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -94,6 +94,7 @@ local _unitAttrs = false
 local _getUnitDataLastRefreshFrame = false
 
 local _injectExtraUnitUpgrades = false
+local _injectOpponentUnitTypeToCount = false
 local _injectExtraModifiers = false
 local _updateWarnings = false
 
@@ -1068,7 +1069,73 @@ function Roller_RollDiceCoroutine()
     end
     coroutine.yield(0)
 
+    -- Reroll misses for any dice that have available rerolls
+    local conductRerolls = false
+    local rerollingDiceByType = {}
+    for _, dice in ipairs(Roller._dice) do
+        local availableRerolls = dice.rerollMisses or 0
+        if availableRerolls > 0 then
+            dice._rerollGuids = {}
+            for i, guid in ipairs(dice._guids) do
+                -- These prooooobably sync up by index. Ensure they do before any merges.
+                local rollValue = dice._rollValues[i]
+
+                if rollValue < dice.hitValue then
+                    table.insert(dice._rerollGuids, guid)
+                    conductRerolls = true
+                    availableRerolls = availableRerolls - 1
+                    if availableRerolls == 0 then
+                        break
+                    end
+                end
+            end
+
+            if #dice._rerollGuids > 0 then
+                dice._originalRollValues = {}
+                -- Copy
+                for _, origRollValue in ipairs(dice._rollValues) do
+                    table.insert(dice._originalRollValues, origRollValue)
+                end
+                dice._rollValues = {}
+            end
+        end
+    end
+
+    -- For any rerolls found, roll the dice! And watch for results.
+    if conductRerolls then
+        for _, dice in ipairs(Roller._dice) do
+            for _, guid in ipairs(dice._rerollGuids or {}) do
+                local die = getObjectFromGUID(guid)
+                die.interactable = false
+                die.roll()
+            end
+        end
+        coroutine.yield(0)
+
+        local timeout = Time.time + 3
+        for _, dice in ipairs(Roller._dice) do
+            dice._rollValues = {}
+            for _, guid in ipairs(dice._guids) do
+                local die = false
+                while true do
+                    die = getObjectFromGUID(guid)  -- re-get every time, can be deleted
+                    if die and (not die.resting) and Time.time < timeout then
+                        coroutine.yield(0)
+                    else
+                        break
+                    end
+                end
+                if die then
+                    table.insert(dice._rollValues, die.getValue() or 0)
+                    die.interactable = true
+                end
+            end
+        end
+        coroutine.yield(0)
+    end
+
     -- Generate report.
+    local specialMessages = {}
     local message = {}
     local hits = 0
     for _, dice in ipairs(Roller._dice) do
@@ -1079,6 +1146,7 @@ function Roller_RollDiceCoroutine()
         item = item .. ']: '
 
         local rollValues = {}
+        local critCount = 0
         local unitHitCount = 0
         for _, rollValue in ipairs(dice._rollValues) do
             local suffix = ''
@@ -1087,20 +1155,42 @@ function Roller_RollDiceCoroutine()
                 unitHitCount = unitHitCount + 1
                 suffix = '#'
             end
-            if dice.critCount and dice.critValue and (rollValue >= dice.critValue) then
-                hits = hits + dice.critCount
-                unitHitCount = unitHitCount + dice.critCount
-                for _ = 1, dice.critCount do
-                    suffix = suffix .. '#'
+            if (dice.critCount or dice.critMessagePrefix) and dice.critValue and (rollValue >= dice.critValue) then
+                if dice.critCount then
+                    hits = hits + dice.critCount
+                    unitHitCount = unitHitCount + dice.critCount
+                    for _ = 1, dice.critCount do
+                        suffix = suffix .. '#'
+                    end
+                end
+                if dice.critMessagePrefix then
+                    critCount = critCount + 1
                 end
             end
             table.insert(rollValues, rollValue .. suffix)
             setHitCount(dice.unitId, unitHitCount)
         end
+
+        if dice._originalRollValues and dice.rerollMisses then
+            local availableRerolls = dice.rerollMisses == 999 and 'all' or dice.rerollMisses
+            table.insert(specialMessages, dice.unitName .. ' rolled values before automatic reroll of ' .. availableRerolls .. ' misses: ' .. table.concat(dice._originalRollValues, ', '))
+        end
+
         table.insert(message, dice.unitName .. ' ' .. item .. table.concat(rollValues, ', '))
+
+        if critCount > 0 and dice.critMessagePrefix then
+            table.insert(specialMessages, dice.critMessagePrefix .. critCount)
+        end
+
+        if dice.availableTargets and dice.availableTargets >= 0 then
+            table.insert(specialMessages, math.max(hits - dice.availableTargets, 0) .. ' hits in excess of available targets.')
+        end
     end
     broadcastToAll(playerName .. ' rolled: [ffffff]' .. table.concat(message, ', '), playerColor)
     broadcastToAll(playerName .. ' landed ' .. hits .. ' hit' .. (hits == 1 and '' or 's') .. '.', playerColor)
+    for _, message in ipairs(specialMessages) do
+        broadcastToAll(playerName .. ': ' .. message)
+    end
 
     Roller._setRollInProgress(false)
     return 1
@@ -1139,6 +1229,9 @@ function rollDiceForAbility(player, ability)
                 hitValue = abilityAttrs.hit,
                 critCount = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.count,
                 critValue = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.value,
+                critMessagePrefix = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.messagePrefix,
+                availableTargets = abilityAttrs.availableTargets,
+                rerollMisses = abilityAttrs.rerollMisses or 0,
                 unitName = unit_stats.name,
                 unitId = unit_id
             })
@@ -1280,7 +1373,7 @@ function getUnitData(force)
         myUnitTypeToCount = unitTypeToCount,
         opponentColor = _vsColor,
         opponentUnitModifiers = opponentModifiers,
-        opponentUnitTypeToCount = false
+        opponentUnitTypeToCount = _injectOpponentUnitTypeToCount
     })
 
     -- Make sure all units have a name and image.
@@ -1310,6 +1403,7 @@ function inject(params)
 
     -- Add these when gathering unit modifiers.
     _injectExtraModifiers = params.extraModifiers or false
+    _injectOpponentUnitTypeToCount = params.opponentUnitTypeToCount or false
     _rollObjectOverride = params.rollObjectGuid and getObjectFromGUID(params.rollObjectGuid)
 
     for _, unitType in ipairs(UNIT_TYPES) do
@@ -1330,6 +1424,7 @@ function inject(params)
 
     -- Require click handling absorb these this frame, otherwise lost.
     _injectExtraModifiers = false
+    _injectOpponentUnitTypeToCount = false
     _rollObjectOverride = false
 end
 

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -94,7 +94,6 @@ local _unitAttrs = false
 local _getUnitDataLastRefreshFrame = false
 
 local _injectExtraUnitUpgrades = false
-local _injectOpponentUnitTypeToCount = false
 local _injectExtraModifiers = false
 local _updateWarnings = false
 
@@ -1181,20 +1180,11 @@ function Roller_RollDiceCoroutine()
             setHitCount(dice.unitId, unitHitCount)
         end
 
-        if dice._originalRollValues and dice.rerollMisses then
-            local availableRerolls = dice.rerollMisses == 999 and 'all' or dice.rerollMisses
-            --table.insert(specialMessages, dice.unitName .. ' rolled values before automatic reroll of ' .. availableRerolls .. ' misses: ' .. table.concat(dice._originalRollValues, ', '))
-        end
-
         table.insert(message, dice.unitName .. ' ' .. item .. table.concat(rollValues, ', '))
 
         if critCount > 0 and dice.critMessage then
             local critMessage = dice.critMessage:gsub('%${PlayerName}', playerName):gsub('%${ExtraHits}', critCount)
             table.insert(specialMessages, critMessage)
-        end
-
-        if dice.availableTargets and dice.availableTargets >= 0 then
-            table.insert(specialMessages, math.max(hits - dice.availableTargets, 0) .. ' hits in excess of available targets.')
         end
     end
     broadcastToAll(playerName .. ' rolled: [ffffff]' .. table.concat(message, ', '), playerColor)
@@ -1241,7 +1231,6 @@ function rollDiceForAbility(player, ability)
                 critCount = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.count,
                 critValue = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.value,
                 critMessage = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.message,
-                availableTargets = abilityAttrs.availableTargets,
                 rerollMisses = abilityAttrs.rerollMisses or 0,
                 unitName = unit_stats.name,
                 unitId = unit_id
@@ -1384,7 +1373,7 @@ function getUnitData(force)
         myUnitTypeToCount = unitTypeToCount,
         opponentColor = _vsColor,
         opponentUnitModifiers = opponentModifiers,
-        opponentUnitTypeToCount = _injectOpponentUnitTypeToCount
+        opponentUnitTypeToCount = false
     })
 
     -- Make sure all units have a name and image.
@@ -1414,7 +1403,6 @@ function inject(params)
 
     -- Add these when gathering unit modifiers.
     _injectExtraModifiers = params.extraModifiers or false
-    _injectOpponentUnitTypeToCount = params.opponentUnitTypeToCount or false
     _rollObjectOverride = params.rollObjectGuid and getObjectFromGUID(params.rollObjectGuid)
 
     for _, unitType in ipairs(UNIT_TYPES) do
@@ -1435,7 +1423,6 @@ function inject(params)
 
     -- Require click handling absorb these this frame, otherwise lost.
     _injectExtraModifiers = false
-    _injectOpponentUnitTypeToCount = false
     _rollObjectOverride = false
 end
 


### PR DESCRIPTION
This is a proof of concept for how we can accommodate the following effects:
- Argent Flight "Raid Formation": Anti-fighter barrage hits in excess of available targets will damage ships with SUSTAIN DAMAGE
- Argent Flight "Strike Wing Alpha II": Anti-Fighter Barrage rolls of 9 or 10 each destroy 1x infantry in the space area
- University of Jol-Nar Commander "Ta Vern": You may reroll dice for non-combat abilities
  - Design note: For the automatic tool, reroll all misses. In practice, this may not be desired.

This works by passing additional parameters to the multiroller, which it uses to reroll some dice, and also generate additional lines of text for the report. This is a really basic proof of concept because I can imagine this whole approach being too poor to pursue.

But, if we do choose to use this method we'll need to make further adjustments (beyond polish of code and report messages). The Raid Formation ability counts available targets separately for each ability...this breaks with the Nomad promissory note and any Franken setup with multiple unit types having Anti-Fighter Barrage abilities in the space area.

Possible alternatives: The AutoFill Multiroller Tool can poll for roll results (perhaps using a request ID), and then do needed processing for extra abilities. But this would make reporting very tricky, when we'll be rerolling some of the multiroller's misses (which it would blindly report).